### PR TITLE
refactor(plugin): rename kmov spells to kubemove

### DIFF
--- a/cmd/kubemove/main.go
+++ b/cmd/kubemove/main.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/spf13/pflag"
 
-	"github.com/kubemove/kubemove/pkg/plugin/v1alpha1"
+	plugin "github.com/kubemove/kubemove/pkg/plugin/v1alpha1"
 )
 
 func main() {
 	flags := pflag.NewFlagSet("kubemove", pflag.ExitOnError)
 	pflag.CommandLine = flags
 
-	root := v1alpha1.NewCmdKubeMove()
+	root := plugin.NewCmdKubeMove()
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/pkg/plugin/v1alpha1/kubemove.go
+++ b/pkg/plugin/v1alpha1/kubemove.go
@@ -5,9 +5,9 @@ import "github.com/spf13/cobra"
 // NewCmdKubeMove returns kubemove root command
 func NewCmdKubeMove() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "kubectl kubemove",
-		Short: "kubemove cli-plugin is used for interacting with kmov operators",
-		Long:  "kubemove cli-plugin is used for interacting with kmov operators",
+		Use:   "kubemove",
+		Short: "kubemove is used for interacting with kmov operators",
+		Long:  "kubemove is used for interacting with kmov operators",
 	}
 	cmd.AddCommand(NewCmdVersion())
 	return cmd

--- a/pkg/plugin/v1alpha1/version.go
+++ b/pkg/plugin/v1alpha1/version.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewCmdVersion returns kmov version command
+// NewCmdVersion returns kubemove version command
 func NewCmdVersion() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
@@ -15,7 +15,7 @@ func NewCmdVersion() *cobra.Command {
 		Long: `Prints version and other details relevant to kubemove plugin
 
 Usage:
-kubectl kubemove version
+kubemove version
 	`,
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("Version: %s\n", "v0.0.1-unreleased")


### PR DESCRIPTION
Signed-off-by: ashishranjan738 <ashishranjan738@gmail.com>

This commit renames kmov spells with kubemove and adds import alias name.