### PR TITLE
enhance(kubemove-cli): adds dummy list command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ go:
 script:
   - make
   - ./_output/bin/kubemove version
+  - ./_output/bin/kubemove list

--- a/pkg/plugin/v1alpha1/kubemove.go
+++ b/pkg/plugin/v1alpha1/kubemove.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+)
 
 // NewCmdKubeMove returns kubemove root command
 func NewCmdKubeMove() *cobra.Command {
@@ -10,5 +12,6 @@ func NewCmdKubeMove() *cobra.Command {
 		Long:  "kubemove is used for interacting with kubemove operators",
 	}
 	cmd.AddCommand(NewCmdVersion())
+	cmd.AddCommand(NewCmdList())
 	return cmd
 }

--- a/pkg/plugin/v1alpha1/list.go
+++ b/pkg/plugin/v1alpha1/list.go
@@ -1,0 +1,29 @@
+package v1alpha1
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+const dummyData = `
+Name        Type
+----        ---- 
+CR1         KubeMovePair
+CR2         KubeMoveSync	
+`
+
+// NewCmdList returns kubemove list command to list the kubemove CRs available in the cluster
+func NewCmdList() *cobra.Command {
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "Prints List of available kubemove CRDs",
+		Long: `Prints List of available kubemove CRDs
+		Usage:
+		kubemove list`,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("%s", dummyData)
+		},
+	}
+	return listCmd
+}


### PR DESCRIPTION
Signed-off-by: ashishranjan738 <ashishranjan738@gmail.com>

This commit adds dummy list commands to kubemove cli which list fake kubemove CR's available.
Output:
```
[aranjan@ashish-pc kubemove]$ ./_output/bin/kubemove list

Name        Type
----        ---- 
CR1         KubeMovePair
CR2         KubeMoveSync
```