### PR TITLE
doc(readme): update with project status meeting link

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,5 @@ We welcome participation from the community in defining more use cases, developi
 
 If you would like to know the ongoing work and its status, you can join us at status [meeting](<https://meet.google.com/ueh-fycm-aex>) that happens every Monday / Wednesday / Friday at 2.30 PM IST.
 
+Minutes of meeting are captured in this [doc](<https://docs.google.com/document/d/1B7y28-WUiOy_RnFVbGF59BDYOMYXV5cPTnfxBbcFXp4/edit?usp=sharing>)
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ KubeMove is developed under Apache 2.0 license.
 # Contributing
 
 We welcome participation from the community in defining more use cases, developing API spec and implementation. Please write new issues as you like.
+
 If you would like to know the ongoing work and its status, you can join us at status [meeting](<https://meet.google.com/ueh-fycm-aex>) that happens every Monday / Wednesday / Friday at 2.30 PM IST.
 
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,6 @@ KubeMove is developed under Apache 2.0 license.
 # Contributing
 
 We welcome participation from the community in defining more use cases, developing API spec and implementation. Please write new issues as you like.
-
+If you would like to know the ongoing work and its status, you can join us at status [meeting](<https://meet.google.com/ueh-fycm-aex>) that happens every Monday / Wednesday / Friday at 2.30 PM IST.
 
 


### PR DESCRIPTION
Currently, ReadMe doesn't have a way to know the status of project.
This PR is to add link to project status meeting that happens every Monday / Wednesday and Friday 2.30PM IST