### PR TITLE
chore(engine): enable resource migration through command line

### DIFF
--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -41,6 +41,7 @@ func main() {
 	// Add the zap logger flag set to the CLI. The flag set must
 	// be added before calling pflag.Parse().
 	pflag.CommandLine.AddFlagSet(zap.FlagSet())
+	pflag.BoolVar(&moveengine.EnableResources, "resource", false, "Enable resource miration.. This feature is in development stage")
 
 	// Add flags registered by imported packages (e.g. glog and
 	// controller-runtime)

--- a/pkg/controller/moveengine/controller.go
+++ b/pkg/controller/moveengine/controller.go
@@ -29,6 +29,9 @@ import (
 
 var log = logf.Log.WithName("controller_moveengine")
 
+// EnableResources defines if resources needs to be migrated
+var EnableResources bool
+
 // Add creates a new MoveEngine Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
@@ -110,7 +113,7 @@ func (r *ReconcileMoveEngine) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	//TODO
-	if r.discoveryHelper == nil {
+	if r.discoveryHelper == nil && EnableResources {
 		if err = r.setupHelper(); err != nil {
 			r.log.Error(err, "Error setting up helper")
 			return reconcile.Result{}, err
@@ -145,9 +148,11 @@ func (r *ReconcileMoveEngine) Reconcile(request reconcile.Request) (reconcile.Re
 
 	//TODO
 	me := engine.NewMoveEngineAction(r.log, r.client, r.discoveryHelper)
-	err = me.ParseResourceEngine(instance)
-	if err != nil {
-		r.log.Error(err, "Failed to parse resources")
+	if EnableResources {
+		err = me.ParseResourceEngine(instance)
+		if err != nil {
+			r.log.Error(err, "Failed to parse resources")
+		}
 	}
 
 	dsName, err := me.CreateDataSync()


### PR DESCRIPTION
By default resource migration will be disabled.
To enable resource migration, run moveengine through 
`kengine --resource=true`

Signed-off-by: mayank <mayank.patel@mayadata.io>